### PR TITLE
♻️  REFACTOR: Simplify render interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ import { renderToString } from "katex"
 import MarkdownIt from "markdown-it"
 import amsmathPlugin from "markdown-it-amsmath"
 
-const mdit = MarkdownIt().use(amsmathPlugin, {
-      renderer: renderToString,
-      options: { throwOnError: false, displayMode: true }
-})
+const katexOptions = { throwOnError: false, displayMode: true }
+const renderer = math => renderToString(math, katexOptions)
+const mdit = MarkdownIt().use(amsmathPlugin, { renderer })
 const text = mdit.render("\\begin{equation}a = 1\\end{equation}")
 ```
 
@@ -39,21 +38,26 @@ In the browser:
 ```html
 <!DOCTYPE html>
 <html>
-    <head>
-        <title>Example Page</title>
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-        <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
-        <script src="https://unpkg.com/markdown-it-amsmath"></script>
-    </head>
-    <body>
-        <div id="demo"></div>
-        <script>
-            const options = { renderer: katex.renderToString, options: { throwOnError: false, displayMode: true }};
-            const text = window.markdownit().use(window.markdownitAmsmath, options).render("\\begin{equation}a = 1\\end{equation}");
-            document.getElementById("demo").innerHTML = text
-        </script>
-    </body>
+  <head>
+    <title>Example Page</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css"
+    />
+    <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
+    <script src="https://unpkg.com/markdown-it-amsmath"></script>
+  </head>
+  <body>
+    <div id="demo"></div>
+    <script>
+      const katexOptions = { throwOnError: false, displayMode: true }
+      const renderer = math => katex.renderToString(math, katexOptions)
+      const mdit = window.markdownit().use(window.markdownitAmsmath, { renderer })
+      const text = mdit.render("\\begin{equation}a = 1\\end{equation}")
+      document.getElementById("demo").innerHTML = text
+    </script>
+  </body>
 </html>
 ```
 
@@ -94,17 +98,15 @@ Finally, you can update the version of your package, e.g.: `npm version patch -m
 Finally, you can adapt the HTML document in `docs/`, to load both markdown-it and the plugin (from [unpkg]), then render text from an input area.
 This can be deployed by [GitHub Pages].
 
-
 [ci-badge]: https://github.com/executablebooks/markdown-it-amsmath/workflows/CI/badge.svg
 [ci-link]: https://github.com/executablebooks/markdown-it--plugin-template/actions
 [npm-badge]: https://img.shields.io/npm/v/markdown-it-amsmath.svg
 [npm-link]: https://www.npmjs.com/package/markdown-it-amsmath
-
-[GitHub Actions]: https://docs.github.com/en/actions
-[GitHub Pages]: https://docs.github.com/en/pages
+[github actions]: https://docs.github.com/en/actions
+[github pages]: https://docs.github.com/en/pages
 [prettier]: https://prettier.io/
 [eslint]: https://eslint.org/
-[Jest]: https://facebook.github.io/jest/
-[Rollup]: https://rollupjs.org
+[jest]: https://facebook.github.io/jest/
+[rollup]: https://rollupjs.org
 [npm]: https://www.npmjs.com
 [unpkg]: https://unpkg.com/

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,12 +1,15 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta charset='utf-8'>
-    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Plugin Demonstration</title>
-    <meta name='viewport' content='width=device-width, initial-scale=1'>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css">
-    <link rel='stylesheet' type='text/css' media='screen' href='main.css'>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.css"
+    />
+    <link rel="stylesheet" type="text/css" media="screen" href="main.css" />
     <script src="https://cdn.jsdelivr.net/npm/markdown-it@12/dist/markdown-it.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/katex/dist/katex.min.js"></script>
     <script src="https://unpkg.com/markdown-it-amsmath"></script>
@@ -20,10 +23,14 @@
       <div class="content">
         <p>
           This is a minimalist demonstration of the
-          <a href="https://github.com/executablebooks/markdown-it-amsmath">markdown-it-amsmath</a> plugin.
+          <a href="https://github.com/executablebooks/markdown-it-amsmath">
+            markdown-it-amsmath
+          </a>
+          plugin.
         </p>
         <p>
-          Simply write in the text box below, then click away, and the text will be rendered.
+          Simply write in the text box below, then click away, and the text will be
+          rendered.
         </p>
         <textarea id="inputtext" class="inputtext" rows="13">
 # Title
@@ -38,27 +45,30 @@ equation with no number:
 
 \begin{equation*}
 a = 1
-\end{equation*}</textarea>
+\end{equation*}
+        </textarea>
         <div id="renderer" class="rendered"></div>
       </div>
     </div>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <script>
       // get elements
-      var inputText = document.getElementById("inputtext");
-      var renderer = document.getElementById("renderer")
+      var inputText = document.getElementById("inputtext")
+      var rendererEl = document.getElementById("renderer")
 
       // setup change handler
-      inputText.onchange = handleChange;
+      inputText.onchange = handleChange
+
+      const katexOptions = { throwOnError: false, displayMode: true }
+      const renderer = math => katex.renderToString(math, katexOptions)
+      const md = window.markdownit().use(window.markdownitAmsmath, { renderer })
       function handleChange(e) {
-        const options = { renderer: katex.renderToString, options: { throwOnError: false, displayMode: true }};
-        const md = window.markdownit().use(window.markdownitAmsmath, options);
-        renderer.innerHTML = md.render(e.target.value)
+        rendererEl.innerHTML = md.render(e.target.value)
       }
 
       // trigger change handler for first render
-      const event = new Event("change");
-      inputText.dispatchEvent(event);
+      const event = new Event("change")
+      inputText.dispatchEvent(event)
     </script>
   </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,21 +4,19 @@ import type StateBlock from "markdown-it/lib/rules_block/state_block"
 
 export interface IOptions {
   // the render function to use
-  renderer?: (content: string, options?: { [key: string]: any }) => string
-  // options to parse to the render function
-  options?: { [key: string]: any }
+  renderer?: (content: string) => string
 }
 
 /**
  * An markdown-it plugin that parses bare LaTeX [amsmath](https://ctan.org/pkg/amsmath) environments.
- * 
+ *
  * ```latex
     \begin{gather*}
       a_1=b_1+c_1\\
       a_2=b_2+c_2-d_2+e_2
     \end{gather*}
   ```
- * 
+ *
  */
 export default function amsmathPlugin(md: MarkdownIt, options?: IOptions): void {
   md.block.ruler.before("blockquote", "amsmath", amsmathBlock, {
@@ -32,7 +30,7 @@ export default function amsmathPlugin(md: MarkdownIt, options?: IOptions): void 
       const content = tokens[idx].content
       let res: string
       try {
-        res = renderer(content, options?.options)
+        res = renderer(content)
       } catch (err) {
         res = md.utils.escapeHtml(`${content}:${err.message}`)
       }

--- a/tests/fixtures.spec.ts
+++ b/tests/fixtures.spec.ts
@@ -28,8 +28,7 @@ describe("Parses basic", () => {
 
   readFixtures("katex").forEach(([name, text, expected]) => {
     const mdit = MarkdownIt().use(amsmathPlugin, {
-      renderer: renderToString,
-      options: { throwOnError: false, displayMode: true }
+      renderer: math => renderToString(math, { throwOnError: false, displayMode: true })
     })
     let rendered = mdit.render(text)
     // remove styles


### PR DESCRIPTION
See #5

Removes the unnecessary (and somewhat confusing) options from the package, allowing future passing of other arguments if we choose, or a different signature for the renderer (multiple arguments, etc.). The readme is updated to explicitly clarify that the options passed in are katex's not anything to do with this package.

This also ran prettier on the html and md.